### PR TITLE
Add Level Editor Guide by me

### DIFF
--- a/Level-Editor.md
+++ b/Level-Editor.md
@@ -2,6 +2,10 @@
 
 There are various videos on the internet documenting the use of the built-in level editor. This is a list of some of the useful ones. However, due to the nature of the internet this list is probably incomplete. You're always welcome to add new ones!
 
+Markdown-based:
+- [0.6.0 Guide](https://github.com/Ordoviz/wiki/blob/master/Editor-Guide-0-6-0.md) by Ordoviz
+
+Videos:
 - [Basic Tutorial](https://www.youtube.com/watch?v=gsuKAy18iWo) by brmbrmcar
 - [Advanced Tutorial](https://www.youtube.com/watch?v=drwLEYo8EVQ) by brmbrmcar
 - [Basic Tutorial (Part 1/2)](https://www.youtube.com/watch?v=mhSNateb4nI) by Oliver Buo


### PR DESCRIPTION
As of now this PR just adds a link to my fork of the wiki but if you want you can adopt the guide into the wiki and change the name to “Official guide”. That way it would be clear that it is meant to be edited by the community. #7 could be closed in favor of this.