### PR TITLE
Scripting: Update and fix formatting

### DIFF
--- a/ScriptingAmbientSound.md
+++ b/ScriptingAmbientSound.md
@@ -18,10 +18,10 @@ In the level file:
       (y 20)
       (width 100)
       (height 51)
-      (distance_factor 0.5)
+      (distance_factor 0)
       (distance_bias 0)
-      (sample "waterfall.wav")
-      (volume 1)
+      (sample "sounds/waterfall.wav")
+      (volume 100)
     )
 
 In a script:
@@ -35,10 +35,11 @@ In the console:
 Methods
 -------
 
-| set\_pos(float x, float y) | Sets the position of the ambient sound |
-|----------------------------|----------------------------------------|
-| get\_pos\_x()              | Returns the x coordinate.              |
-| get\_pos\_y()              | Returns the y coordinate.              |
+| Method                      | Explanation                             |
+|---------------------------- |---------------------------------------- |
+| `set_pos(float x, float y)` | Sets the position of the ambient sound. |
+| `float get_pos_x()`         | Returns the x coordinate.               |
+| `float get_pos_y()`         | Returns the y coordinate.               |
 
 Constants
 ---------

--- a/ScriptingAmbientSound.md
+++ b/ScriptingAmbientSound.md
@@ -6,7 +6,7 @@ An ambient sound that was given a name can be controlled by scripts.
 Instance
 --------
 
-An `AmbientSound` is instantiated by placing a definition inside a level. It can then be accessed by its `name` from a script or via `sector.`*`name`* from the console.
+An `AmbientSound` is instantiated by placing a definition inside a level. It can then be accessed by its `name` from a script or via <code>sector.<var>name</var></code> from the console.
 
 ### Example
 

--- a/ScriptingAmbientSound.md
+++ b/ScriptingAmbientSound.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -46,7 +44,3 @@ Constants
 ---------
 
 -   *None*
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingCamera.md
+++ b/ScriptingCamera.md
@@ -8,33 +8,34 @@ Instances
 
 An instance named `Camera` (`sector.Camera` in the console) is available. *(Note: doesn't having a class and an eponymous instance create a potential for conflicts? We should probably rename the instance or the class.)*
 
-The *mode* of the camera is either **normal** (the camera is following the player) or **autoscroll**. In the latter mode the camera is forced along a specified [path](ScriptingPath "wikilink"). The left and right borders of the screen are solid. If the player fails to hold up with the moving camera, [Tux](Tux "wikilink") is pushed forward according to the camera movement, possibly squishing him when he is between the border of the screen and other solid objects.
+The *mode* of the camera is either **normal** (the camera is following the player) or **autoscroll**. In the latter mode the camera is forced along a specified [path](ScriptingPath "wikilink").
 
 ### Example
 
-`(camera`
-`  (mode `“`autoscroll`”`)`
-`  (path`
-`    (node`
-`      (x 0)`
-`      (y 0)`
-`      (time 250)`
-`    )`
-`    (node`
-`      (x 19072)`
-`      (y 0)`
-`    )`
-`  )`
-`)`
+    (camera
+      (mode "autoscroll")
+      (path
+        (node
+          (x 0)
+          (y 0)
+          (time 250)
+        )
+        (node
+          (x 19072)
+          (y 0)
+        )
+      )
+    )
 
 Methods
 -------
 
-| shake(float time, float x, float y)      | Shakes camera in the vector specified by x and y.                                                |
-|------------------------------------------|--------------------------------------------------------------------------------------------------|
-| set\_pos(float x, float y)               | Moves the camera to the specified position. Warning: This function has not yet been implemented. |
-| set\_mode(string modestring)             | This function sets the camera mode. Valid values for `modestring` are “`normal`” and “`manual`”. |
-| scroll\_to(float x, float y, float time) | Scrolls the camera to (`x`, `y`) within `time` seconds.                                          |
+Method                                    | Explanation
+------------------------------------------|-------------------------------------
+`shake(float time, float x, float y)`     | Moves camera to the given coordinates in <var>time</var> seconds returning quickly to the original position after that.
+`set_pos(float x, float y)`               | Moves the camera to the specified absolute position. The origin is at the top left.
+`set_mode(string modestring)`             | This function sets the camera mode. Valid values for <var>modestring</var> are “normal” and “manual”.
+`scroll_to(float x, float y, float time)` | Scrolls the camera to the given coordinates within <var>time</var> seconds.
 
 Constants
 ---------

--- a/ScriptingCamera.md
+++ b/ScriptingCamera.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -42,7 +40,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingCandle.md
+++ b/ScriptingCandle.md
@@ -30,9 +30,10 @@ Console usage:
 Methods
 -------
 
-| get\_burning()             | returns true if candle is lighted            |
-|----------------------------|----------------------------------------------|
-| set\_burning(bool burning) | true: light candle, false: extinguish candle |
+Method                      | Explanation
+----------------------------|---------------------------------------------------
+`bool get_burning()`        | Returns true if candle is lighted.
+`set_burning(bool burning)` | Lights candle if true; extinguishes candle if false.
 
 Constants
 ---------

--- a/ScriptingCandle.md
+++ b/ScriptingCandle.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -40,7 +38,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingCandle.md
+++ b/ScriptingCandle.md
@@ -6,7 +6,7 @@ A Candle object that was given a name can be controlled by scripts.
 Instances
 ---------
 
-A `Candle` is instantiated via a definition in a level. It can be accessed by its `name` in scripts and via `sector.`*`name`* in the console.
+A `Candle` is instantiated via a definition in a level. It can be accessed by its `name` in scripts and via <code>sector.<var>name</var></code> in the console.
 
 ### Example
 

--- a/ScriptingDisplayEffect.md
+++ b/ScriptingDisplayEffect.md
@@ -11,37 +11,14 @@ SuperTux creates an instance named `Effect` when starting the scripting engine. 
 Methods
 -------
 
-<table>
-<thead>
-<tr class="header">
-<th><p>fade_out(float fadetime)</p></th>
-<th><p>Gradually fades out the screen to black for the next <code>fadetime</code> seconds.</p></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p>fade_in(float fadetime)</p></td>
-<td><p>Gradually fades in the screen from black for the next <code>fadetime</code> seconds.</p></td>
-</tr>
-<tr class="even">
-<td><p>set_black(bool black)</p></td>
-<td><p>Blackens or un-blackens the screen (depending on the value of <code>black</code>).</p></td>
-</tr>
-<tr class="odd">
-<td><p>is_black()</p></td>
-<td><p>Returns: <code>bool</code>; has the screen been blackened by <code>set_black</code>?<br />
-Note: Calling <code>fade_in</code> or <code>fade_out</code> resets the return value to <code>false</code>.</p></td>
-</tr>
-<tr class="even">
-<td><p>sixteen_to_nine(float fadetime)</p></td>
-<td><p>Sets the display ratio to 16:9, effectively adding black bars at the top and bottom of the screen. Should be used before cutscenes. Gradually fades to this state for the next <code>fadetime</code> seconds.</p></td>
-</tr>
-<tr class="odd">
-<td><p>four_to_three(float fadetime)</p></td>
-<td><p>Sets the display ratio to 4:3, removing the black bars added by <code>sixteen_to_nine()</code>. Should be used after cutscenes. Gradually fades to this state for the next <code>fadetime</code> seconds.</p></td>
-</tr>
-</tbody>
-</table>
+Method                            | Explanation
+----------------------------------|---------------------------------------------
+`fade_out(float fadetime)`        | Gradually fades out the screen to black for the next <var>fadetime</var> seconds.
+`fade_in(float fadetime)`         | Gradually fades in the screen from black for the next <var>fadetime</var> seconds.
+`set_black(bool black)`           | Blackens or un-blackens the screen (depending on the value of <var>black</var>).
+`is_black()`                      | Returns: `bool`; has the screen been blackened by `set_black` Note: Calling `fade_in` or `fade_out` resets the return value to `false`.
+`sixteen_to_nine(float fadetime)` | Sets the display ratio to 16:9, effectively adding black bars at the top and bottom of the screen. Should be used before cutscenes. Gradually fades to this state for the next <var>fadetime</var> seconds.
+`four_to_three(float fadetime)`   | Sets the display ratio to 4:3, removing the black bars added by `sixteen_to_nine()`. Should be used after cutscenes. Gradually fades to this state for the next <var>fadetime</var> seconds.
 
 Constants
 ---------

--- a/ScriptingDisplayEffect.md
+++ b/ScriptingDisplayEffect.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -49,7 +47,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingFloatingImage.md
+++ b/ScriptingFloatingImage.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -53,7 +51,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingFloatingImage.md
+++ b/ScriptingFloatingImage.md
@@ -6,46 +6,46 @@ This class provides the ability to create, edit, and remove images floating in m
 Instances
 ---------
 
-Floating Images are created in a script or from the console. Constructor: <code>
+Floating Images are created in a script or from the console. Constructor:
 
-`<floatimage> <- FloatingImage(string filename)`
+    <floatimage> <- FloatingImage(string filename)
 
-</code> Creates a FloatingImage from `filename` (which is relative to the data root).
+This creates a FloatingImage from <var>filename</var> (which is relative to the data root).
 
 ### Example
 
-Definition of the logo in the menu level: <code>
+Definition of the logo in the menu level:
 
-`(init-script "`
-`  logo <- FloatingImage(\`“`images/objects/logo/logo.sprite\`”`);`
-`  logo.set_anchor_point(ANCHOR_TOP);`
-`  logo.set_pos(0, 30);`
-`  logo.set_visible(true);`
-`  // Suspend (this is needed so that logo doesn't get deleted)`
-`  suspend();`
-`")`
+    (sector
+      (init-script "
+        logo <- FloatingImage(\"images/objects/logo/logo_final.sprite\");
+        logo.set_anchor_point(ANCHOR_MIDDLE);
+        logo.set_pos(0, -171);
+        logo.set_visible(true);
+      ")
+      …
+    )
 
-</code>
-
-The above creates a floating image name “logo”, anchors it to the top, set its position relative to that anchor, and finally displays it instantaneously. To use this in the console, remove the init script and ending lisp tags.
+The above creates a floating image name “logo”, anchors it to the middle, set its position relative to that anchor, and finally displays it instantaneously. To use this in the console, remove the init script and ending lisp tags.
 
 Methods
 -------
 
-| void set\_layer(int layer)          | Moves this image to the layer `layer`. See src/video/drawing\_context.hpp for the predefined layers and their values (note that you can't yet use these constants in your Squirrel code). |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| int get\_layer()                    | Returns: `int`; the layer the floating image is on.                                                                                                                                       |
-| void set\_pos(float x, float y)     | Sets the position of this image to (x,y) | Move the image in relation to the current anchor point.                                                                                        |
-| int get\_x()                        | Returns the x position of this image. | Get the image's X coordinate relative to the current anchor point.                                                                                |
-| int get\_y()                        | Returns the y position of this image. | Get the image's Y coordinate relative to the current anchor point.                                                                                |
-| int get\_anchor\_point()            | Returns the current anchor point of this image. (See set\_anchor\_point for a list of values) | Returns: `int`; the current anchor point                                                  |
-| void set\_anchor\_point(int anchor) | Set the image's anchor point. Possible values are represented by the [ANCHOR\_\* constants](ScriptingGlobals#Constants "wikilink").                                                       |
-| string get\_action()                | Returns the name of the current action of this image. (Only useful for sprites)                                                                                                           |
-| set\_action(string action)          | Sets the current action of this image. (Only useful for sprites)                                                                                                                          |
-| bool get\_visible()                 | Returns the current visibility of this image.                                                                                                                                             |
-| set\_visible(bool visible)          | Shows or hides the image abruptly according to visible (drastic counterpart to `fade_in` and `fade_out`).                                                                                 |
-| fade\_in(float time)                | Fades in this image for the next `time` seconds.                                                                                                                                          |
-| fade\_out(float time)               | Just the opposite of `fade_in`.                                                                                                                                                           |
+Method                           | Explanation
+-------------------------------- |---------------------------------------------
+`set_layer(int layer)`           | Moves this image to the layer <var>layer</var> aka z-position.
+`int get_layer()`                | Returns: `int`; the layer the floating image is on.
+`set_pos(float x, float y)`      | Sets the position of this image in relation to the current anchor point.
+`int get_x()`                    | Returns the x position of this image relative to the current anchor point.
+`int get_y()`                    | Returns the y position of this image relative to the current anchor point.
+`int get_anchor_point()`         | Returns the current anchor point of this image.
+`set_anchor_point(int anchor)`   | Set the image's anchor point. Possible values are represented by the [ANCHOR\_\* constants](ScriptingGlobals#Constants "wikilink").
+`string get_action()`            | Returns the name of the current action of this image. (Only useful for sprites)
+`set_action(string action)`      | Sets the current action of this image. (Only useful for sprites)
+`bool get_visible()`             | Returns the current visibility of this image.
+`set_visible(bool visible)`      | Shows or hides the image abruptly according to <var>visible</var> (drastic counterpart to `fade_in` and `fade_out`).
+`fade_in(float time)`            | Fades in this image for the next <var>time</var> seconds.
+`fade_out(float time)`           | Just the opposite of `fade_in`.
 
 Constants
 ---------

--- a/ScriptingGlobals.md
+++ b/ScriptingGlobals.md
@@ -54,7 +54,3 @@ Constants
 | ANCHOR\_TOP\_RIGHT    | represents the top right anchor point of a rectangle     |
 | ANCHOR\_BOTTOM\_LEFT  | represents the bottom left anchor point of a rectangle   |
 | ANCHOR\_BOTTOM\_RIGHT | represents the bottom right anchor point of a rectangle  |
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingGlobals.md
+++ b/ScriptingGlobals.md
@@ -1,56 +1,64 @@
 Summary
-=======
+-------
 
 This module contains global constants and methods.
 
 Methods
-=======
+-------
 
-| display(\*\*\* object)                                      | Displays the string value of `object` in the [Console](Console "wikilink"). Object can be of any data type.                                                                                     |
-|-------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| print\_stacktrace()                                         | Displays contents of the current stack.                                                                                                                                                         |
-| load\_worldmap(string filename)                             | Loads and runs the worldmap specified in `filename`. (The path is relative to the data root.)                                                                                                   |
-| load\_level(string filename)                                | Loads and runs the level specified in `filename`. (The path is relative to the data root.)                                                                                                      |
-| get\_current\_thread()                                      | Returns the currently running thread.                                                                                                                                                           |
-| display\_text\_file(string filename)                        | Displays the SuperTux text file named `filename`. (The path is relative to the data root, e.g. “/home/joe/src/supertux-trunk/data”) See also: SuperTux file format reference, SuperTux texts    |
-| wait(float time)                                            | Pauses execution of the Squirrel code for `time` seconds.                                                                                                                                       |
-| wait\_for\_screenswitch()                                   | Pauses execution of the Squirrel code until a new screen is displayed (e.g. menu → worldmap or worldmap → level).                                                                               |
-| exit\_screen()                                              | Exits the current screen, returning to the previous one or, if the active screen is the last one, exiting SuperTux.                                                                             |
-| fadeout\_screen(float seconds)                              | Does a fadeout for the specified number of seconds before next screenchange.                                                                                                                    |
-| shrink\_screen(float dest\_x, float dest\_y, float seconds) | Does a shrinking fade towards the destposition for the specified number of seconds before next screenchange.                                                                                    |
-| translate(string text)                                      | Returns: translated `string`. Translates `text` into the user's locale. Note: This construct is unfortunately not yet recognized by XGetText, so translation files have to be written manually. |
-| import(string filename)                                     | Imports and runs the Squirrel script `filename`. (The path is relative to the data root.)                                                                                                       |
-| save\_state()                                               | Dumps the current state into the user's save game file.                                                                                                                                         |
-| update\_worldmap()                                          | Update worldmap from worldmap state (state.world variable)                                                                                                                                      |
-| play\_music(string musicfile)                               | Changes music to musicfile                                                                                                                                                                      |
-| play\_sound(string soundfile)                               | Plays a soundfile                                                                                                                                                                               |
-| debug\_collrects(bool enable)                               | Enables or disables drawing of collision rectangles.                                                                                                                                            |
-| debug\_show\_fps(bool enable)                               | Enables or disables drawing of the FPS. (Also affects config file)                                                                                                                              |
-| debug\_draw\_solids\_only(bool enable)                      | When enabled, only draws solid tilemaps. (No background/foreground tiles)                                                                                                                       |
-| set\_game\_speed(float speed)                               | Set speed to run the game at. (Doesn't affect menus/gui)                                                                                                                                        |
-| grease()                                                    | Speeds Tux's horizontal velocity by a factor of 3.                                                                                                                                              |
-| ghost()                                                     | Makes Tux a ghost, letting him float around and through objects.                                                                                                                                |
-| invincible()                                                | Make Tux invincible for 10000 units of game time.                                                                                                                                               |
-| mortal()                                                    | Recall Tux's invincibility or ghost status. (Even when not given with above 2 commands)                                                                                                         |
-| restart()                                                   | Reinitialize and respawn Tux at the beginning of the current level.                                                                                                                             |
-| whereami()                                                  | Print out Tux's coordinates to the console.                                                                                                                                                     |
-| gotoend()                                                   | Moves Tux horizontally 2 screens away from the end.                                                                                                                                             |
-| camera()                                                    | Display the current camera's coordinates. (top-left corner)                                                                                                                                     |
-| quit()                                                      | Exits the game. (Not recommended for use in levels!)                                                                                                                                            |
-| int rand()                                                  | Returns a random evenly-distributed integer between 0 and 2147483647, inclusive.                                                                                                                |
-| record\_demo(string filename)                               | Record a demo to the given file.                                                                                                                                                                |
-| play\_demo(string filename)                                 | Play back a demo from the given file.                                                                                                                                                           |
+Method                                | Explanation
+--------------------------------------|-----------------------------------------
+`display(*** object)`                 | Displays the string value of <var>object</var> in the [Console](Console "wikilink"). Object can be of any data type.
+`print_stacktrace()`                  | Displays contents of the current stack.
+`bool is_christmas()`                 | Returns whether Christmas mode is enabled.
+`load_worldmap(string filename)`      | Loads and runs the worldmap specified in <var>filename</var>. (The path is relative to the data root.)
+`set_next_worldmap(string dirname, string spawnpoint)` | Switches to a different worldmap after unloading current one, after `exit_screen()` is called.
+`load_level(string filename)`         | Loads and runs the level specified in <var>filename</var>. (The path is relative to the data root.)
+`get_current_thread()`                | Returns the currently running thread.
+`display_text_file(string filename)`  | Displays the SuperTux text file named <var>filename</var>. (The path is relative to the data root, e.g. “/usr/share/games/supertux2/”)
+`wait(float time)`                    | Pauses execution of the Squirrel code for <var>time</var> seconds.
+`wait_for_screenswitch()`             | Pauses execution of the Squirrel code until a new screen is displayed (e.g. menu → worldmap or worldmap → level).
+`exit_screen()`                       | Exits the current screen, returning to the previous one or, if the active screen is the last one, exiting SuperTux.
+`string translate(string text)`       | Translates <var>text</var> into the user's locale. Note: This construct is unfortunately not yet recognized by XGetText, so translation files have to be written manually.
+`string translate_plural(string text, string text_plural, int num)` | Returns <var>text</var> or <var>text_plural</var> depending on <var>num</var> and the locale.
+`import(string filename)`             | Imports and runs the Squirrel script <var>filename</var>. (The path is relative to the data root.)
+`save_state()`                        | Dumps the current state into the user's save game file.
+`load_state()`                        | Loads world state from scripting table.
+`play_music(string musicfile)`        | Plays music, e.g. “antarctica/chipdisko.music”.
+`stop_music(float fadetime)`          | Fades out music in <var>fadetime</var> seconds.
+`play_sound(string soundfile)`        | Plays sound, e.g “sounds/lifeup.wav”.
+`debug_collrects(bool enable)`        | Enables or disables drawing of collision rectangles.
+`debug_show_fps(bool enable)`         | Enables or disables drawing of the FPS. (Also affects config file)
+`debug_draw_solids_only(bool enable)` | When enabled, only draws solid tilemaps. (No background/foreground tiles)
+`debug_draw_editor_images(bool enable)` | Enables or disables drawing of editor images. 
+`debug_worldmap_ghost(bool enable)`   | Enables or disables worldmap ghost mode.
+`set_game_speed(float speed)`         | Sets speed to run the game at. (Doesn't affect menus/gui)
+`grease()`                            | Speeds Tux's horizontal velocity by a factor of 3.
+`ghost()`                             | Makes Tux a ghost, letting him float around and through objects.
+`invincible()`                        | Makes Tux invincible for 10000 units of game time.
+`mortal()`                            | Recalls Tux's invincibility or ghost status. (Even when not given with above 2 commands)
+`restart()`                           | Reinitializes and respawn Tux at the beginning of the current level.
+`whereami()`                          | Prints out Tux's coordinates to the console.
+`gotoend()`                           | Moves Tux horizontally 2 screens away from the end.
+`warp(float x, float y)`              | Moves Tux <var>x</var> tiles to the right and <var>y</var> tiles to the bottom.
+`camera()`                            | Displays the current camera's coordinates. (top-left corner)
+`set_gamma(float gamma)`              | Sets gamma (brightness).
+`quit()`                              | Exits the game. (Not recommended for use in levels!)
+`int rand()`                          | Returns a random evenly-distributed integer between 0 and 2147483647, inclusive.
+`record_demo(string filename)`        | Records a demo to the given file.
+`play_demo(string filename)`          | Plays back a demo from the given file.
 
 Constants
-=========
+---------
 
-| ANCHOR\_TOP           | represents the top center anchor point of a rectangle    |
-|-----------------------|----------------------------------------------------------|
-| ANCHOR\_BOTTOM        | represents the bottom center anchor point of a rectangle |
-| ANCHOR\_LEFT          | represents the left anchor point of a rectangle          |
-| ANCHOR\_RIGHT         | represents the right anchor point of a rectangle         |
-| ANCHOR\_MIDDLE        | represents the middle anchor point of a rectangle        |
-| ANCHOR\_TOP\_LEFT     | represents the top left anchor point of a rectangle      |
-| ANCHOR\_TOP\_RIGHT    | represents the top right anchor point of a rectangle     |
-| ANCHOR\_BOTTOM\_LEFT  | represents the bottom left anchor point of a rectangle   |
-| ANCHOR\_BOTTOM\_RIGHT | represents the bottom right anchor point of a rectangle  |
+Constant              | Explanation
+----------------------|---------------------------------------------------------
+`ANCHOR_TOP`          | Represents the top center anchor point of a rectangle.
+`ANCHOR_BOTTOM`       | Represents the bottom center anchor point of a rectangle.
+`ANCHOR_LEFT`         | Represents the left anchor point of a rectangle.
+`ANCHOR_RIGHT`        | Represents the right anchor point of a rectangle.
+`ANCHOR_MIDDLE`       | Represents the middle anchor point of a rectangle.
+`ANCHOR_TOP_LEFT`     | Represents the top left anchor point of a rectangle.
+`ANCHOR_TOP_RIGHT`    | Represents the top right anchor point of a rectangle.
+`ANCHOR_BOTTOM_LEFT`  | Represents the bottom left anchor point of a rectangle.
+`ANCHOR_BOTTOM_RIGHT` | Represents the bottom right anchor point of a rectangle.

--- a/ScriptingLevel.md
+++ b/ScriptingLevel.md
@@ -11,35 +11,13 @@ An instance named `Level` is available from scripts and the console. *(Note: cla
 Methods
 -------
 
-<table>
-<thead>
-<tr class="header">
-<th><p>finish(bool win)</p></th>
-<th><p>Ends the current level. If you set <code>win</code> to <code>true</code>, the level is marked as completed if launched from a worldmap.<br />
-Tip: Very useful if you have created a frustrating level and want to, at some point, save the player from agony.</p></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p>spawn(string sectorname, string spawnpointname)</p></td>
-<td><p>Respawns Tux in the sector <code>sectorname</code> at the <code>spawnpointname</code> spawnpoint.<br />
-<em>Exceptions</em>: If <code>sectorname</code> or <code>spawnpointname</code> are empty or the specified sector does not exist, the function will bail out first chance it gets. If the specified spawnpoint doesn't exist, Tux will be spawned at the spawnpoint named <code>main</code>. If this spawnpoint doesn't exist either, Tux will simply end up at the origin (top-left 0, 0).</p></td>
-</tr>
-<tr class="even">
-<td><p>flip_vertically()</p></td>
-<td><p>Flips the level vertically (i.e. top is now bottom and vice versa). Call again to revert the effect.<br />
-Tip: Make sure the player can land on something after the level is flipped!</p></td>
-</tr>
-<tr class="odd">
-<td><p>toggle_pause()</p></td>
-<td><p>Toggle pause</p></td>
-</tr>
-<tr class="even">
-<td><p>Level_edit(bool editing)</p></td>
-<td><p>Change to/from edit mode</p></td>
-</tr>
-</tbody>
-</table>
+Method                                   | Explanation
+-----------------------------------------|--------------------------------------
+`finish(bool win)`                       | Ends the current level. If you set <var>win</var> to `true`, the level is marked as completed if launched from a worldmap.
+`spawn(string sector string spawnpoint)` | Respawns Tux in sector <var>sector</var> at spawnpoint <var>spawnpoint</var>. Exceptions: If <var>sector</var> or <var>spawnpoint</var> are empty or the specified sector does not exist, the function will bail out first chance it gets. If the specified spawnpoint doesn't exist, Tux will be spawned at the spawnpoint named “main”. If this spawnpoint doesn't exist either, Tux will simply end up at the origin (top-left 0, 0).
+`flip_vertically()`                      | Flips the level vertically (i.e. top is now bottom and vice versa). Call again to revert the effect. Make sure the player can land on something after the level is flipped!
+`toggle_pause()`                         | Toggle pause.
+`edit(bool editing)`                     | Change to/from edit mode.
 
 Constants
 ---------
@@ -53,8 +31,8 @@ Example code
 
 The following code teleports the player to [spawnpoint](spawnpoint "wikilink") “main” in [sector](sector "wikilink") “underground”.
 
-`(scripttrigger`
-`  (script `“`Level.spawn(\`”`underground\`“`,`` ``\`”`main\`“`);]]`”`)`
-`  (button #f)`
-`  ...`
-`)`
+    (scripttrigger
+      (script "Level.spawn(\"underground\", \"main\");")
+      (button #f)
+      ...
+    )

--- a/ScriptingLevel.md
+++ b/ScriptingLevel.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -60,7 +58,3 @@ The following code teleports the player to [spawnpoint](spawnpoint "wikilink") �
 `  (button #f)`
 `  ...`
 `)`
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingLevelTime.md
+++ b/ScriptingLevelTime.md
@@ -6,7 +6,7 @@ A `LevelTime` object that is given a name can be controlled by scripts.
 Instances
 ---------
 
-A `LevelTime` object is instantiated by a definition in the level file. It can be accessed by scripts using its `name` and from the console as `sector.`*`name`*.
+A `LevelTime` object is instantiated by a definition in the level file. It can be accessed by scripts using its `name` and from the console as <code>sector.<var>name</var></code>.
 
 ### Example
 

--- a/ScriptingLevelTime.md
+++ b/ScriptingLevelTime.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -46,7 +44,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingLevelTime.md
+++ b/ScriptingLevelTime.md
@@ -34,11 +34,12 @@ This will stop the time.
 Methods
 -------
 
-| start()                          | Resumes the countdown (assuming it isn't already started, in which case it does nothing) |
-|----------------------------------|------------------------------------------------------------------------------------------|
-| stop()                           | Pauses the countdown (assuming it isn't already stopped, in which case it does nothing)  |
-| float get\_time()                | Returns the number of seconds left on the clock                                          |
-| void set\_time(float time\_left) | Changes the number of seconds left on the clock                                          |
+Method                      | Explanation
+----------------------------|---------------------------------------------------
+`start()`                   | Resumes the countdown (assuming it isn't already started, in which case it does nothing).
+`stop()`                    | Pauses the countdown (assuming it isn't already stopped, in which case it does nothing).
+`float get_time()`          | Returns the number of seconds left on the clock.
+`set_time(float time_left)` | Changes the number of seconds left on the clock.
 
 Constants
 ---------

--- a/ScriptingPath.md
+++ b/ScriptingPath.md
@@ -3,19 +3,19 @@ A **Path** is a series of points that can be followed by some objects. This way 
 Synopsis
 --------
 
-`(path`
-`  (mode `“`circular`”`)`
-`  (node`
-`    (x 800)`
-`    (y 96)`
-`    (time 0.3)`
-`  )`
-`  (node`
-`    (x 832)`
-`    (y 96)`
-`    (time 1.0)`
-`  )`
-`)`
+    (path
+      (mode "circular")
+      (node
+        (x 800)
+        (y 96)
+        (time 0.3)
+      )
+      (node
+        (x 832)
+        (y 96)
+        (time 1.0)
+      )
+    )
 
 Syntax
 ------
@@ -26,48 +26,48 @@ A path consists of a *mode* setting and one or more *nodes*.
 
 The *mode* specifies the behavior at the end of the path when automatic movement is activated, i.e. the object is going to all nodes in order one by one (rather than being told to go to a specific node and stay there). It takes one string argument with the following possible values:
 
--   **circular**
+-   **circular:**
     After reaching the last node go directly back to the first node, forming a circle.
--   **pingpong**
+-   **pingpong:**
     After reaching the last node go back the path, visiting all nodes in reverse order. This is especially useful for moving platforms that go back and forth a specific path.
--   **oneshot**
+-   **oneshot:**
     When reaching the last node, stay there.
-    *(FIXME: I have no idea if this is correct)*
--   **unordered**
+-   **unordered:**
     Travels to a random node and never stops. Goes directly to given node when not running.
 
 **Example:**
 
-`(mode `“`circular`”`)`
+    (mode "circular")
 
 ### Nodes
 
 Nodes are points in the level along which the associated object moves. They have the following attributes:
 
--   **x**
+-   **x:**
     x-coordinate of the point in *pixels*.
--   **y**
+-   **y:**
     y-coordinate of the point in *pixels*.
--   **time** *(optional)*
+-   **time:** *(optional)*
     Time it takes to move to the *next* point in seconds. Defaults to one second.
 
 **Example:**
 
-`(node`
-`  (x 42)`
-`  (y 23)`
-`  (time 1.337)`
-`)`
+    (node
+      (x 42)
+      (y 23)
+      (time 1.337)
+    )
 
 Scripting
 ---------
 
 Objects a path is associated with usually provide the following methods:
 
-| goto\_node(int node\_no) | advance until at given node, then stop. Nodes are numbered from 0 to *n* − 1. |
-|--------------------------|-------------------------------------------------------------------------------|
-| start\_moving()          | start advancing automatically                                                 |
-| stop\_moving()           | stop advancing automatically                                                  |
+Method                   | Explanation
+-------------------------|------------------------------------------------------
+`goto_node(int node_no)` | Advances until at given node, then stops. The index of the first node is 0.
+`start_moving()`         | Starts advancing automatically.
+`stop_moving()`          | Stops advancing automatically.
 
 Used by
 -------

--- a/ScriptingPath.md
+++ b/ScriptingPath.md
@@ -76,7 +76,3 @@ Used by
 -   [Platform](ScriptingPlatform "wikilink")
 -   [Tilemap](ScriptingTilemap "wikilink")
 -   [Will-o-wisp](ScriptingWill-o-wisp "wikilink")
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingPlatform.md
+++ b/ScriptingPlatform.md
@@ -12,22 +12,22 @@ An instance is created by being defined in a level. It may be accessed via its `
 
 Example of a definition:
 
-      (platform
-        (name "PLATFORM1")
-        (running #f)
-        (sprite "images/objects/platforms/vertical-wood.sprite")
-        (path
-          (mode "circular")
-          (node
-            (x 832)
-            (y 800)
-          )
-          (node
-            (x 832)
-            (y 704)
-          )
+    (platform
+      (name "PLATFORM1")
+      (running #f)
+      (sprite "images/objects/platforms/vertical-wood.sprite")
+      (path
+        (mode "circular")
+        (node
+          (x 832)
+          (y 800)
         )
-      ) 
+        (node
+          (x 832)
+          (y 704)
+        )
+      )
+    ) 
      
 
 The above object will be exposed under the name PLATFORM1 in the scripting engine. Example usage:
@@ -42,10 +42,12 @@ From console:
 Methods
 -------
 
-| goto\_node(int node\_no) | advance until at given node, then stop. |
-|--------------------------|-----------------------------------------|
-| start\_moving()          | start advancing automatically           |
-| stop\_moving()           | stop advancing automatically            |
+Method                   | Explanation
+-------------------------|------------------------------------------
+`goto_node(int node_no)` | Advances until at given node, then stops.
+`start_moving()`         | Starts advancing automatically.
+`stop_moving()`          | Stops advancing automatically.
+`set_action(string action, int repeat)` | Sets the sprite action.
 
 Constants
 ---------

--- a/ScriptingPlatform.md
+++ b/ScriptingPlatform.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -53,7 +51,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingPlatform.md
+++ b/ScriptingPlatform.md
@@ -6,7 +6,7 @@ A [Moving platform](Moving_platform "wikilink") that was given a name can be con
 Instances
 ---------
 
-An instance is created by being defined in a level. It may be accessed via its `name` from scripts and via `sector.`*`name`* from the console.
+An instance is created by being defined in a level. It may be accessed via its `name` from scripts and via <code>sector.<var>name</var></code> from the console.
 
 ### Example
 

--- a/ScriptingPlayer.md
+++ b/ScriptingPlayer.md
@@ -11,92 +11,33 @@ Due to SuperTux's single-player nature, there is only one instance of the `Playe
 Methods
 -------
 
-<table>
-<thead>
-<tr class="header">
-<th><p>add_bonus(string bonusname)</p></th>
-<th><p>Gives Tux the specified bonus. Replace <code>bonusname</code> with either of “<code>grow</code>”, “<code>fireflower</code>” or “<code>iceflower</code>”.</p></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p>add_coins(int number)</p></td>
-<td><p>Gives Tux <code>number</code> coins.<br />
-Tip: Tux has to pay 25 coins to be revived at the last firefly he visited. If he doesn't have enough coins, the player has to play the whole level again.</p></td>
-</tr>
-<tr class="even">
-<td><p>make_invincible()</p></td>
-<td><p>Makes the player invincible for either a predefined amount of time.<br />
-See also: <code>TUX_INVINCIBLE_TIME</code> in src/object/player.hpp for the amount of seconds that the player becomes invincible.</p></td>
-</tr>
-<tr class="odd">
-<td><p>deactivate()</p></td>
-<td><p>Stops the player and blocks the movement controls.<br />
-Tip: Don't call this in front of a horde of badguys. Carried items like trampolines won't be dropped.</p></td>
-</tr>
-<tr class="even">
-<td><p>activate()</p></td>
-<td><p>Reactivates the player's movement controls.</p></td>
-</tr>
-<tr class="odd">
-<td><p>walk(float speed)</p></td>
-<td><p>Make Tux walk</p></td>
-</tr>
-<tr class="even">
-<td><p>set_visible(bool visible)</p></td>
-<td><p>Shows or hides Tux according to the value of <code>visible</code>. Note: Tux doesn't interact with objects or badguys while invisible.</p></td>
-</tr>
-<tr class="odd">
-<td><p>get_visible()</p></td>
-<td><p>Returns: <code>bool</code>; is Tux visible?</p></td>
-</tr>
-<tr class="even">
-<td><p>kill(bool completely)</p></td>
-<td><p>Hurts a player, if completely=true then the player will be killed even if he had grow or fireflower bonus.</p></td>
-</tr>
-<tr class="odd">
-<td><p>set_ghost_mode(bool enable)</p></td>
-<td><p>Switches ghost mode on/off.<br />
-Lets Tux float around and through solid objects.</p></td>
-</tr>
-<tr class="even">
-<td><p>get_ghost_mode()</p></td>
-<td><p>Returns whether ghost mode is currently enabled</p></td>
-</tr>
-<tr class="odd">
-<td><p>do_cheer()</p></td>
-<td><p>Makes Tux cheer, if possible.</p></td>
-</tr>
-<tr class="even">
-<td><p>do_duck()</p></td>
-<td><p>Makes Tux duck, if possible.</p></td>
-</tr>
-<tr class="odd">
-<td><p>do_standup()</p></td>
-<td><p>Makes Tux stand up, if possible.</p></td>
-</tr>
-<tr class="even">
-<td><p>do_backflip()</p></td>
-<td><p>Makes Tux backflip, if possible.</p></td>
-</tr>
-<tr class="odd">
-<td><p>do_jump()</p></td>
-<td><p>Makes Tux jump, if possible.</p></td>
-</tr>
-<tr class="even">
-<td><p>trigger_sequence(string sequence_name)</p></td>
-<td><p>Orders the current GameSession to start a sequence. One of “stoptux”, “endsequence”, or “fireworks”.</p></td>
-</tr>
-<tr class="odd">
-<td><p>use_scripting_controller(bool use_or_release)</p></td>
-<td><p>Uses a scriptable controller for all user input (or restores controls)</p></td>
-</tr>
-<tr class="even">
-<td><p>do_scripting_controller(string control, bool pressed)</p></td>
-<td><p>Instructs the scriptable controller to press or release a button. control can be “left”, “right”, “up”, “down”, “jump”, “action”, “pause-menu”, “menu-select”, “console”, “peek-left”, or “peek-right”.</p></td>
-</tr>
-</tbody>
-</table>
+Method                        | Explanation                                  
+----------------------------- | ---------------------------------------------
+`add_bonus(string bonusname)` | Gives Tux the specified bonus unless Tux’s current bonus is superior. Replace <var>bonusname</var> with “grow”, “fireflower”, “iceflower”, “airflower”, or “earthflower”.
+`set_bonus(string bonusname)` | Gives Tux the specified bonus. Replace <var>bonusname</var> with “grow”, “fireflower”, “iceflower”, “airflower”, “earthflower”, or “none”.
+`add_coins(int number)`       | Gives Tux <var>number</var> coins.
+`int get_coins()`             | Returns the number of coins Tux has.
+`make_invincible()`           | Makes the player invincible for a predefined amount of time specified with `TUX_INVINCIBLE_TIME` in src/object/player.cpp.
+`deactivate()`                | Stops the player and blocks the movement controls. Carried items like trampolines won't be dropped.
+`activate()`                  | Reactivates the player's movement controls.
+`walk(float speed)`           | Makes Tux walk.
+`set_dir(bool right)`         | Changes Tux’s direction. Use `true` to make Tux face right and `false` to make him face left.
+`set_visible(bool visible)`   | Shows or hides Tux according to the value of <var>visible</var>. Tux doesn't interact with objects or badguys while invisible.
+`bool get_visible()`          | Returns `true` if Tux is visible.
+`kill(bool completely)`       | Hurts a player. If <var>completely</var> is `true`, the player will be killed regardless of the current bonus.
+`set_ghost_mode(bool enable)` | Switches ghost mode on/off. Lets Tux float around through solid objects.
+`bool get_ghost_mode()`       | Returns whether ghost mode is currently enabled.
+`do_cheer()`                  | Makes Tux cheer, if possible.
+`do_duck()`                   | Makes Tux duck, if possible.
+`do_standup()`                | Makes Tux stand up, if possible.
+`do_backflip()`               | Makes Tux backflip, if possible.
+`do_jump()`                   | Makes Tux jump, if possible.
+`trigger_sequence(string sequence_name)` | Orders the current GameSession to start a sequence. One of “stoptux”, “endsequence”, or “fireworks”.
+`use_scripting_controller(bool use_or_release)` | Uses a scriptable controller for all user input (or restores controls).
+`do_scripting_controller(string control, bool pressed)` | Instructs the scriptable controller to press or release a button. <var>control</var> can be “left”, “right”, “up”, “down”, “jump”, “action”, “start”, “escape”, “menu-select”, “menu-select-space”, “menu-back”, “remove”, “cheat-menu”, “debug-menu”, “console”, “peek-left”, “peek-right”, “peek-up”, or “peek-down”,
+`float get_velocity_x()`      | Return Tux’s velocity in x direction.
+`float get_velocity_y()`      | Return Tux’s velocity in y direction.
+`bool has_grabbed(string name)` | Return `true` if Tux carries a <var>name</var> object.
 
 Constants
 ---------

--- a/ScriptingPlayer.md
+++ b/ScriptingPlayer.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -104,7 +102,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingScriptedObject.md
+++ b/ScriptingScriptedObject.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -68,7 +66,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingScriptedObject.md
+++ b/ScriptingScriptedObject.md
@@ -12,55 +12,51 @@ ScriptedObjects are created by being defined in level files. Each scripted objec
 
 Example of a definition:
 
-      (scriptedobject
-        (x 2291)
-        (y 1275)
-        (name "SUPERTUX")
-        (sprite "images/creatures/tux_big/tux.sprite")
-        (layer 100)
-        (visible #t)
-        (physic-enabled #t)
-        (solid #t)
-      ) 
-     
-
+    (scriptedobject
+      (x 50)
+      (y 50)
+      (name "SUPERTUX")
+      (sprite "images/creatures/tux/tux.sprite")
+    )
+   
 The above object will be exposed under the name `SUPERTUX` in the scripting engine. Example usage:
 
-      // This script will make tux look and walk left/right (this should make him appear
-      //   "upset")
-      SUPERTUX.set_action("stand-right");
-      wait(2);
-      SUPERTUX.set_velocity(200,0);
-      wait(0.3);
-      SUPERTUX.set_velocity(0,0);
-      wait(0.4);
-      SUPERTUX.set_action("stand-left");
-      SUPERTUX.set_velocity(-200,0);
-      wait(0.3);
+    // This script will make tux look and walk left/right (this should make him
+    // appear "upset")
+    SUPERTUX.set_action("big-stand-right");
+    wait(2);
+    SUPERTUX.set_velocity(200,0);
+    wait(0.3);
+    SUPERTUX.set_velocity(0,0);
+    wait(0.4);
+    SUPERTUX.set_action("big-stand-left");
+    SUPERTUX.set_velocity(-200,0);
+    wait(0.3);
      
 
-The object can be accessed from the console `sector.SUPERTUX`.
+The object can be accessed from the console as `sector.SUPERTUX`.
 
 Methods
 -------
 
-| set\_action(string animation)          | Activates the sprite's action specified in `animation`.                                                   |
-|----------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| get\_action()                          | Returns the name of the sprite's current action.                                                          |
-| move(float x, float y)                 | Moves the object by `x` units to the right and `y` down relative to its current position.                 |
-| set\_pos(float x, float y)             | Basically identical to `move`, except its relativity to the sector origin.                                |
-| get\_pos\_x()                          | Returns the X coordinate of the object's position.                                                        |
-| get\_pos\_y()                          | Returns the Y coordinate of the object's position.                                                        |
-| set\_velocity(float x, float y)        | Makes the object move in a certain direction (with a certain speed) given by the `x` and `y` coordinates. |
-| get\_velocity\_x()                     | Returns the X coordinate of the object's velocity.                                                        |
-| get\_velocity\_y()                     | Returns the Y coordinate of the object's velocity.                                                        |
-| enable\_gravity(bool gravity\_enabled) | Shows or hides the object according to the value of `gravity_enabled`.                                    |
-| gravity\_enabled()                     | Returns true if the object's gravity is enabled, false otherwise.                                         |
-| set\_visible(bool visible)             | Shows or hides the object according to the value of `visible`.                                            |
-| is\_visible()                          | Returns true if the object is visible, false otherwise.                                                   |
-| set\_solid(bool solid)                 | Makes the object solid according to the value of `solid`.                                                 |
-| is\_solid()                            | Returns true if the object is solid, false otherwise.                                                     |
-| get\_name()                            | Returns the name of the object                                                                            |
+Method                                 | Explanation
+---------------------------------------|----------------------------------------
+`set_action(string animation)`         | Activates the sprite's action specified in <var>animation</var>.
+`string get_action()`                  | Returns the name of the sprite's current action.
+`move(float x, float y)`               | Moves the object by <var>x</var> units to the right and <var>y</var> down relative to its current position.
+`set_pos(float x, float y)`            | Basically identical to `move`, except its relativity to the sector origin.
+`float get_pos_x()`                    | Returns the X coordinate of the object's position.
+`float get_pos_y()`                    | Returns the Y coordinate of the object's position.
+`set_velocity(float x, float y)`       | Makes the object move in a certain <var>x</var> and <var>y</var> direction (with a certain speed).
+`float get_velocity_x()`               | Returns the X coordinate of the object's velocity.
+`float get_velocity_y()`               | Returns the Y coordinate of the object's velocity.
+`enable_gravity(bool gravity_enabled)` | Enables or disables gravity according to the value of <var>gravity_enabled</var>.
+`bool gravity_enabled()`               | Returns true if the object's gravity is enabled, false otherwise.
+`set_visible(bool visible)`            | Shows or hides the object according to the value of <var>visible</var>.
+`bool is_visible()`                    | Returns true if the object is visible, false otherwise.
+`set_solid(bool solid)`                | Changes the solidity according to the value of <var>solid</var>.
+`bool is_solid()`                      | Returns true if the object is solid, false otherwise.
+`string get_name()`                    | Returns the name of the object.
 
 Constants
 ---------

--- a/ScriptingSector.md
+++ b/ScriptingSector.md
@@ -6,30 +6,36 @@ The `Sector` class provides basic controlling functions for the current sector.
 Instances
 ---------
 
-An instance under sector.settings is available from scripts and the console.
+An instance under `sector.settings` is available from scripts and the console.
 
 Methods
 -------
 
 <table>
-<thead>
-<tr class="header">
-<th><p>float get_ambient_light_red()<br />
-float get_ambient_light_green()<br />
-float get_ambient_light_blue()</p></th>
-<th><p>Returns the specified channel of the ambient light color.</p></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p>set_ambient_light(float red, float green, float blue)</p></td>
-<td><p>Sets the sector's ambient light to the specified color.</p></td>
-</tr>
-<tr class="even">
-<td><p>set_gravity(float gravity)</p></td>
-<td><p>Sets the sector's gravity.</p></td>
-</tr>
-</tbody>
+ <tr>
+  <td><code>fade_to_ambient_light(float red, float green, float blue, float
+  fadetime)</code></td>
+  <td>Fades to specified ambient light color in <var>fadetime</var> seconds.</td>
+ </tr>
+ <tr>
+  <td><code>float get_ambient_red()</code></td>
+  <td rowspan=3>Returns the specified channel of the ambient light color.</td>
+ </tr>
+ <tr><td><code>float get_ambient_green()</code></td></tr>
+ <tr><td><code>float get_ambient_blue()</code></td></tr>
+ </tr>
+ <tr>
+  <td><code>set_ambient_light(float red, float green, float blue)</code></td>
+  <td>Sets the sector's ambient light to the specified color.</td>
+ </tr>
+ <tr>
+  <td><code>set_gravity(float gravity)</code></td>
+  <td>Sets the sector's gravity.</td>
+ </tr>
+ <tr>
+  <td><code>set_music(string filename)</code></td>
+  <td>Sets the sector's music (full filename relative to the music folder).</td>
+ </tr>
 </table>
 
 Constants

--- a/ScriptingSector.md
+++ b/ScriptingSector.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -38,7 +36,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingSound.md
+++ b/ScriptingSound.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -16,7 +14,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingSound.md
+++ b/ScriptingSound.md
@@ -3,12 +3,19 @@ Summary
 
 This class provides a very simple interface to the audio subsystem.
 
+### Examples
+
+    play_music("antarctic/chipdisko.music");
+    play_sound("sounds/lifeup.wav");
+
 Methods
 -------
 
-| play\_music(string track\_name) | Plays the selected music track (automatically prepending the path to the music folder and appending the `.ogg` extension). |
-|---------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| play\_sound(string sound\_name) | Plays the sound specified in `sound_name` (that is identical to the filename of the sound without the `.wav` extension).   |
+Method                          | Explanation
+--------------------------------|-----------------------------------------------
+`play_music(string track_name)` | Plays the selected music track (full filename relative to the music folder).
+`stop_music(float fadetime)`    | Fades out currently playing music in <var>fadetime</var> seconds.
+`play_sound(string sound_name)` | Plays the sound <var>sound_name</var> (full filename relative to the data directory).
 
 Constants
 ---------

--- a/ScriptingText.md
+++ b/ScriptingText.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -30,7 +28,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingText.md
+++ b/ScriptingText.md
@@ -11,18 +11,19 @@ An eponymous instance (`Text`) can be accessed from scripts. The console allows 
 Methods
 -------
 
-| set\_text(string text)         | Sets the text string to be displayed to `text`.                                                                                     |
-|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| set\_font(string font)         | Sets the font of the text to be displayed to `text`. Currently valid values are `gold`, `white`, `blue`, `gray`, `big` and `small`. |
-| fade\_in(float time)           | Fades in the specified text for the next `time` seconds.                                                                            |
-| fade\_out(float time)          | Just the opposite of `fade_in`.                                                                                                     |
-| set\_visible(bool visible)     | Shows or hides the text abruptly (drastic counterpart to `fade_in` and `fade_out`).                                                 |
-| set\_centered(bool centered)   | If `centered` is `true`, the text will be centered on the screen. Otherwise, it will be left-aligned.                               |
-| set\_pos(float x, float y)     | Set offset of the text relative to anchor point.                                                                                    |
-| float get\_pos\_x()            | Returns x offset of text relative to anchor point                                                                                   |
-| float get\_pos\_y()            | Returns y offset of text relative to anchor point                                                                                   |
-| set\_anchor\_point(int anchor) | Set anchor point of text; one of the [ANCHOR\_\*](ScriptingGlobals#Constants "wikilink") constants                                  |
-| int get\_anchor\_point()       | Returns current anchor point of text; one of the [ANCHOR\_\*](ScriptingGlobals#Constants "wikilink") constants                      |
+Method                         | Explanation
+-------------------------------|------------------------------------------------
+`set_text(string text)`        | Sets the text string to be displayed to <var>text</var>.
+`set_font(string font)`        | Sets the font of the text to be displayed. Valid values are `normal`, `big` and `small`.
+`fade_in(float time)`          | Fades in the specified text for the next <var>time</var> seconds.
+`fade_out(float time)`         | Just the opposite of `fade_in`.
+`set_visible(bool visible)`    | Shows or hides the text abruptly (drastic counterpart to `fade_in` and `fade_out`).
+`set_centered(bool centered)`  | If <var>centered</var> is `true`, the text will be centered on the screen. Otherwise, it will be left-aligned.
+`set_pos(float x, float y)`    | Sets offset of the text relative to anchor point.
+`float get_pos_x()`            | Returns x offset of text relative to anchor point.
+`float get_pos_y()`            | Returns y offset of text relative to anchor point.
+`set_anchor_point(int anchor)` | Sets anchor point of text; one of the [ANCHOR\_\*](ScriptingGlobals#Constants "wikilink") constants.
+`int get_anchor_point()`       | Returns current anchor point of text; one of the [ANCHOR\_\*](ScriptingGlobals#Constants "wikilink") constants.
 
 Constants
 ---------

--- a/ScriptingThunderstorm.md
+++ b/ScriptingThunderstorm.md
@@ -6,7 +6,7 @@ A [Thunderstorm](Thunderstorm "wikilink") object that was given a name can be co
 Instances
 ---------
 
-A `Thunderstorm` is initialised by a definition in the level. It can be accessed via its `name` in scripts and `sector.`*`name`* in the console.
+A `Thunderstorm` is initialised by a definition in the level. It can be accessed via its `name` in scripts and <code>sector.<var>name</var></code> in the console.
 
 ### Example
 

--- a/ScriptingThunderstorm.md
+++ b/ScriptingThunderstorm.md
@@ -30,13 +30,14 @@ In the console:
 Methods
 -------
 
-| start()     | Start playing thunder and lightning at configured interval   |
-|-------------|--------------------------------------------------------------|
-| stop()      | Stop playing thunder and lightning at configured interval    |
-| thunder()   | Play thunder                                                 |
-| lightning() | Play lightning, i.e. call flash() and electrify()            |
-| flash()     | Display a nice flash                                         |
-| electrify() | Electrify water throughout the whole sector for a short time |
+Method        | Explanation
+--------------|--------------------------------------------------------------
+`start()`     | Starts playing thunder and lightning at configured interval.
+`stop()`      | Stops playing thunder and lightning at configured interval.
+`thunder()`   | Plays thunder.
+`lightning()` | Plays lightning, i.e. call `flash()` and `electrify()`.
+`flash()`     | Displays a flash.
+`electrify()` | Electrifies water throughout the whole sector for a short time.
 
 Constants
 ---------

--- a/ScriptingThunderstorm.md
+++ b/ScriptingThunderstorm.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -44,7 +42,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingTilemap.md
+++ b/ScriptingTilemap.md
@@ -6,7 +6,7 @@ A [Tilemap](Tilemap "wikilink") that was given a name can be controlled by scrip
 Instances
 ---------
 
-An instance is created by being defined in a level. It may be accessed via its `name` from scripts and via `sector.`*`name`* from the console.
+An instance is created by being defined in a level. It may be accessed via its `name` from scripts and via <code>sector.<var>name</var></code> from the console.
 
 ### Example
 

--- a/ScriptingTilemap.md
+++ b/ScriptingTilemap.md
@@ -12,55 +12,56 @@ An instance is created by being defined in a level. It may be accessed via its `
 
 Example of a definition:
 
-<code>
-` (tilemap`
-`   (name `“`niftymap`”`)`
-`   (path`
-`     (mode `“`circular`”`)`
-`     (node`
-`       (x 832)`
-`       (y 800)`
-`       (time 10)`
-`     )`
-`     (node`
-`       (x 832)`
-`       (y 704)`
-`       (time 10)`
-`     )`
-`   )`
-`   (width …)`
-`   (height …)`
-`   (tiles …)`
-`   (solid #t)`
-` ) `
-</code>
+    (tilemap
+      (name "niftymap")
+      (path
+        (mode "circular")
+        (node
+          (x 832)
+          (y 800)
+          (time 10)
+        )
+        (node
+          (x 832)
+          (y 704)
+          (time 10)
+        )
+      )
+      (width …)
+      (height …)
+      (tiles …)
+      (solid #t)
+    ) 
 
 The above tilemap will be exposed under the name “niftymap” in the scripting engine. Example usage:
 
-<code>
-` niftymap.goto_node(1);`
-` niftymap.fade(0.0, 10);`
-</code>
+    niftymap.goto_node(1);
+    niftymap.fade(0.0, 10);
 
 This will cause the tilemap to slowly move left, fading out as it goes, and disappear completely when it reaches its destination. Never fear, though; it is still there. From the console, you can enter:
 
-<code>
+    sector.niftymap.goto_node(0);
+    sector.niftymap.fade(1.0, 15)
 
-` sector.niftymap.goto_node(0);`
-` sector.niftymap.fade(1.0, 15)`
-
-</code> The tilemap will then reverse its previous actions, ending up back where it started, but it will only reach full opacity 5 seconds after it stops.
+ The tilemap will then reverse its previous actions, ending up back where it started, but it will only reach full opacity 5 seconds after it stops.
 
 Methods
 -------
 
-| goto\_node(int node\_no)         | Move tilemap along path until at given node, then stop.                                                                                        |
-|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| start\_moving()                  | Start moving tilemap                                                                                                                           |
-| stop\_moving()                   | Stop tilemap at next node                                                                                                                      |
-| fade(float alpha, float seconds) | Start fading the tilemap to opacity given by alpha. Destination opacity will be reached after seconds game seconds. Also influences solidity.  |
-| set\_alpha(float alpha)          | Instantly switch tilemap's opacity to alpha. Also influences solidity.                                                                         |
-| float get\_alpha()               | Return the tilemap's opacity. Note that while the tilemap is fading in or out, this will return the current alpha value, not the target alpha. |
+Method                                     | Explanation
+-------------------------------------------|------------------------------------
+`goto_node(int node_no)`                   | Moves tilemap along path until at given node, then stop.
+`start_moving()`                           | Starts moving tilemap.
+`stop_moving()`                            | Stops tilemap at next node.
+`int get_tile_id(int x, int y)`            | Returns the id of the tile at the given coordinates or <output>0</output> if out of bounds. The origin is at the top left.
+`int get_tile_id_at(float x, float y)`     | Wrapper for `get_tile_id` that subtracts an offset and divides the arguments by 32 first.
+`change(int x, int y, int newtile)`        | Changes tile at given coordinates to <var>newtile</var>.
+`change_at(float x, float y, int newtile)` | Wrapper for `change` that subtracts an offset and divides the arguments by 32 first.
+`float get_alpha()`                        | Returns the tilemap's opacity. Note that while the tilemap is fading in or out, this will return the current alpha value, not the target alpha.
+`set_alpha(float alpha)`                   | Instantly switches tilemap's opacity to <var>alpha</var>. Also influences solidity.
+`fade(float alpha, float seconds)`         | Fades the tilemap to opacity given by <var>alpha</var> in <var>seconds</var> seconds. Also influences solidity.
+`tint_fade(float seconds, float red, float greens, float blue, float alpha)` | Fade to given tint color in <var>seconds</var> seconds. The tint is applied on all tiles on the tilemap.
+`set_solid(bool solid)`                    | If `false` is given, Tux cannot interact with the tilemap. Make sure every sector has at least one solid tilemap.
 
 Constants
 ---------

--- a/ScriptingTilemap.md
+++ b/ScriptingTilemap.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -68,7 +66,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingWill-o-wisp.md
+++ b/ScriptingWill-o-wisp.md
@@ -6,17 +6,22 @@ Will-o-Wisps, when given a name (and perhaps a [path](ScriptingPath "wikilink") 
 Methods
 -------
 
-| goto\_node(int node\_no) | Move willowisp to given node.                                                     |
-|--------------------------|-----------------------------------------------------------------------------------|
-| start\_moving()          | start following the path                                                          |
-| stop\_moving()           | stop following the path                                                           |
-| set\_state(string state) | set the willowisp state, can be:                                                  
-                                                                                     
-  -   stopped: willowisp doesn't move                                                
-  -   move\_path: willowisp moves along the path (call goto\_node)                   
-  -   move\_path\_track: willowisp moves along path but catches Tux when he is near  
-  -   normal: “normal” mode starts tracking tux when he is near enough               
-  -   vanish: willowisp vanishes                                                     |
+Method                    | Explanation
+--------------------------|----------------------------------------------------
+`goto_node(int node_no)`  | Move willowisp to given node.
+`start_moving()`          | Start following the path.
+`stop_moving()`           | Stop following the path.
+`set_state(string state)` | Set the willowisp state to one of the below values.
+
+States
+------
+
+- stopped: willowisp doesn't move
+- idle: willowisp stops tracking Tux if he is distant enough 
+- move\_path: willowisp moves along the path (call `goto_node`)
+- move\_path\_track: willowisp moves along path but catches Tux when he is near
+- normal: “normal” mode starts tracking Tux when he is near enough
+- vanish: willowisp vanishes
 
 Constants
 ---------

--- a/ScriptingWill-o-wisp.md
+++ b/ScriptingWill-o-wisp.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -24,7 +22,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/ScriptingWind.md
+++ b/ScriptingWind.md
@@ -6,7 +6,7 @@ A Wind object that was given a name can be controlled by scripts.
 Instances
 ---------
 
-A `Wind` is instantiated by a definition in the level file. It can be accessed by scripts using its `name` and from the console as `sector.`*`name`*.
+A `Wind` is instantiated by a definition in the level file. It can be accessed by scripts using its `name` and from the console as <code>sector.<var>name</var></code>.
 
 ### Example
 

--- a/ScriptingWind.md
+++ b/ScriptingWind.md
@@ -35,9 +35,10 @@ Console access:
 Methods
 -------
 
-| start() | start blowing |
-|---------|---------------|
-| stop()  | stop blowing  |
+| Method    | Explanation   |
+|-----------|---------------|
+| `start()` | start blowing |
+| `stop()`  | stop blowing  |
 
 Constants
 ---------

--- a/ScriptingWind.md
+++ b/ScriptingWind.md
@@ -1,5 +1,3 @@
-\_\_NOTOC\_\_
-
 Summary
 -------
 
@@ -45,7 +43,3 @@ Constants
 ---------
 
 None
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/Scripting_reference.md
+++ b/Scripting_reference.md
@@ -83,7 +83,3 @@ using a function that actually doesn't exist.
 * [[ScriptingWind]]
 
 TODO: Improve format maybe?
-
-[Template:Navbox Scripting reference](Template:Navbox_Scripting_reference "wikilink")
-
-[Category:Scripting Reference](Category:Scripting_Reference "wikilink")

--- a/Scripting_reference.md
+++ b/Scripting_reference.md
@@ -81,5 +81,3 @@ using a function that actually doesn't exist.
 * [[ScriptingTilemap]]
 * [[ScriptingWill-o-wisp]]
 * [[ScriptingWind]]
-
-TODO: Improve format maybe?


### PR DESCRIPTION
While fixing the broken format of the Scripting wiki pages, I also checked if the information given is still up-to date and added new methods from the `src/scripting/*.hpp` files. Theoretically, it would be possible to generate the wiki pages from those files.