### PR TITLE
IRC chat has moved from Freenode to Libera Chat

### DIFF
--- a/IRC.rst
+++ b/IRC.rst
@@ -4,10 +4,10 @@ While there might be some people in the channel, they might not always be
 available to help you. If no-one answers to your questions, please wait and
 don't leave the channel. Also, do not ask to ask a question. Just ask.
 
-Our channel is on the `freenode IRC network <https://freenode.net/>`__. If you
+Our channel is on the `Libera Chat IRC network <https://libera.chat/>`__. If you
 simply want to start, just use the
-`webchat <https://kiwiirc.com/client/chat.freenode.net:+6697/#supertux>`__.
+`webchat <https://kiwiirc.com/nextclient/irc.libera.chat:+6697/?nick=Guest?#supertux>`__.
 
 There are also different desktop clients such as HexChat. If you use one of
-them, you will want to connect to `chat.freenode.net` on port 6697 (SSL
-enabled) or 6667 (no SSL) and join the channel `#supertux`.
+them, you will want to connect to `irc.libera.chat` on port 6697 (TLS) and
+join the channel `#supertux`.


### PR DESCRIPTION
The IRC page (being linked from the website) was still referring to Freenode, while the supertux channel switched to Libera Chat as many other projects did. see also https://github.com/SuperTux/supertux/pull/1765