### PR TITLE
Fix expired and missing Discord links

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -11,7 +11,7 @@ Generic instructions
 
 These instructions apply to every function you may want to adopt.
 
-1.  Join the SuperTux Discord to stay up to date with recent developments.
+1.  Join the [SuperTux Discord](https://discord.gg/AcvtHWz) to stay up to date with recent developments.
 2.  Check out the latest SuperTux [development version](Download/Subversion "wikilink") and compile it by following the instructions in the [INSTALL file](http://supertux.lethargik.org/svn/supertux/trunk/supertux/INSTALL) if you want to develop code or levels.
 3.  Modify or add something that is either listed in the [task list](Milestone_2_Design_Document/Tasks "wikilink") or seems useful to you.
 4.  Give us your work:

--- a/Home.md
+++ b/Home.md
@@ -67,13 +67,13 @@ For Players
 Learn how to play with the [[User Manual]]
 
 Chat on the [SuperTux Forum](http://forum.freegamedev.net/viewforum.php?f=66&sid=7d271ca537028e81027e0b3cdab4f0ca)
-or our [Discord](https://discord.gg/zSBqVvkx)
+or our [Discord](https://discord.gg/AcvtHWz)
 
 For Level Designer
 ------------------
 
 Share your levels on the [SuperTux Forum](http://forum.freegamedev.net/viewforum.php?f=66&sid=7d271ca537028e81027e0b3cdab4f0ca),
-or our [Discord](https://discord.gg/zSBqVvkx) and if we like the look of them, you may be able to submit levels to the official game.
+or our [Discord](https://discord.gg/AcvtHWz) and if we like the look of them, you may be able to submit levels to the official game.
 
 Submit your own level packs or worlds to the [Addon Repository](https://github.com/SuperTux/addons) so more players can see and play
 your levels.


### PR DESCRIPTION
Fixes two expired Discord links in `Home.md` and adds a link to the Discord server in `Contributing.md`, where it is mentioned.

Fixes [#1896](https://github.com/SuperTux/supertux/issues/1896) in [SuperTux/supertux](https://github.com/SuperTux/supertux).